### PR TITLE
using pygount for loc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ PyYAML
 httpx
 semgrep
 boto3
+pygount=1.6.1
 azure-identity
 azure-mgmt-compute
 azure-mgmt-network

--- a/verinfast/agent.py
+++ b/verinfast/agent.py
@@ -121,7 +121,7 @@ def main():
             # Check if SEMGrep is installed
             checkDependency("semgrep", "SEMGrep")
 
-            # Check if SEMGrep is installed
+            # Check if Pygount is installed
             checkDependency("pygount", "Pygount")
 
             if shouldUpload:
@@ -193,11 +193,12 @@ def chunks(lst, n):
 
 ###### Setup ######
 def checkDependency(command, name):
-    if not shutil.which(command):
+    which = shutil.which(command)
+    if not which:
         debugLog.log(msg=f"{name} is required but it's not installed.", tag=f"{name} status", display=False)
         raise Exception(f"{name} is required but it's not installed.")
     else:
-        debugLog.log(msg=f"{name} is installed.", tag=f"{name} status", display=True)
+        debugLog.log(msg=f"{name} is installed at {which}.", tag=f"{name} status", display=True)
 
 def global_dependencies():
     # Check if Python3 is installed. This would catch if run with Python 2
@@ -446,8 +447,8 @@ def scanRepos(config):
                 parseRepo(temp_dir, repo_name)
 
                 os.chdir(curr_dir)
-                #if not dry:
-                    #shutil.rmtree(temp_dir)
+                if not dry:
+                    shutil.rmtree(temp_dir)
         else:
              debugLog.log(msg='', tag="No remote repos", display=True)
     else:
@@ -490,7 +491,7 @@ def scanCloud(config):
             upload(file=aws_instance_file, route=f"/report/{config['report']['id']}/instances", source="AWS")
 
         if(provider["provider"] == "azure"):
-            # Check if AWS-CLI is installed
+            # Check if Azure CLI is installed
             checkDependency("az", "Azure Command-line tool")
 
             azure_cost_file = runAzure(subscription_id=provider["account"], start=provider["start"], end=provider["end"], path_to_output=output_dir)
@@ -501,6 +502,9 @@ def scanCloud(config):
             upload(file=azure_instance_file, route=f"/report/{config['report']['id']}/instances", source="Azure")
 
         if provider["provider"] == "gcp":
+            # Check if Google Cloud CLI is installed
+            checkDependency("gcloud", "Google Command-line tool")
+
             gcp_instance_file = get_gcp_instances(sub_id=provider["account"], path_to_output=output_dir)
             debugLog.log(msg=gcp_instance_file, tag="GCP instances")
             upload(file=gcp_instance_file, route=f"/report/{config['report']['id']}/instances", source="GCP")

--- a/verinfast/agent.py
+++ b/verinfast/agent.py
@@ -64,6 +64,7 @@ from cloud.gcp.instances import get_instances as get_gcp_instances
 requestx = httpx.Client(http2=True,timeout=None)
 
 shouldUpload = False
+shouldManualFileScan = True
 dry = False # Flag to not run scans, just upload files (if shouldUpload==True)
 config = FileNotFoundError
 reportId = 0
@@ -86,6 +87,7 @@ debugLog.log(msg='', tag="Started")
 
 def main():
     global shouldUpload
+    global shouldManualFileScan
     global dry
     global reportId
     global baseUrl
@@ -100,6 +102,7 @@ def main():
     global_dependencies()
 
     shouldUpload = config['should_upload']
+    shouldManualFileScan = config['should_manual_filescan'] if 'should_manual_filescan' in config else shouldManualFileScan
     debugLog.log(msg=shouldUpload, tag="Should upload", display=True)
     reportId = config['report']['id']
     baseUrl = config['baseurl']
@@ -118,11 +121,13 @@ def main():
             # Check if SEMGrep is installed
             checkDependency("semgrep", "SEMGrep")
 
+            # Check if SEMGrep is installed
+            checkDependency("pygount", "Pygount")
+
             if shouldUpload:
                 headers = {
                     'content-type': 'application/json',
                     'Accept-Charset': 'UTF-8',
-                    #'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'
                 }
                 debugLog.log(msg=f"{baseUrl}/report/{reportId}/CorsisCode", tag="Report Run Id Fetch", display=True)
                 response = requestx.get(f"{baseUrl}/report/{reportId}/CorsisCode", headers=headers)
@@ -307,8 +312,8 @@ def parseRepo(path:str, repo_name:str):
 
     upload(git_output_file, f"/report/{config['report']['id']}/CorsisCode/{corsisId}/{repo_name}/git", repo_name)
 
+    # Manual File Sizes and Info
     if not dry:
-        # File Sizes and Info
         debugLog.log(msg=repo_name, tag="Gathering file sizes for", display=True)
         # Sizes for writing to output file
         # Intialize file list with "." as total size
@@ -344,32 +349,44 @@ def parseRepo(path:str, repo_name:str):
                 extRe = re.search("^[^\.]*\.(.*)", name)
                 ext = extRe.group(1) if extRe else ''
                 if allowfile(path=fp):
-                    file = {
-                        "size" : os.path.getsize(fp),
-                        "loc" : getloc(fp),
-                        "ext" : ext, #os.path.splitext(name)[1],
-                        "directory" : False
-                    }
-                    sizes["files"][fp] = file
+                    if shouldManualFileScan:
+                        file = {
+                            "size" : os.path.getsize(fp),
+                            "loc" : getloc(fp),
+                            "ext" : ext, #os.path.splitext(name)[1],
+                            "directory" : False
+                        }
+                        sizes["files"][fp] = file
                     filelist.append({"name":name,"path":fp})
 
     sizes_output_file = os.path.join(output_dir, repo_name + ".sizes.json")
-    
+
     if not dry:
         with open(sizes_output_file, 'w') as f:
             f.write(json.dumps(sizes, indent=4))
-
     upload(sizes_output_file, f"/report/{config['report']['id']}/CorsisCode/{corsisId}/{repo_name}/sizes", repo_name)
 
+    # Run Pygount
+    pygount_output_file = os.path.join(output_dir, repo_name + ".pygount.json")
     if not dry:
-        # Run Modernmetric
-        debugLog.log(msg=repo_name, tag="Analyzing repository with Modernmetric", display=True)
+        debugLog.log(msg=repo_name, tag="Getting LOC from repository", display=True)
+        subprocess.check_call([
+            "pygount",
+            "-F=.git,node_modules", # Folders to ignore
+            "--format=json",
+            "-o",
+            pygount_output_file,
+            "." # Scan current directory
+        ])
+    upload(pygount_output_file, f"/report/{config['report']['id']}/CorsisCode/{corsisId}/{repo_name}/pygount", repo_name)
 
+    # Run Modernmetric
     stats_input_file = os.path.join(output_dir, repo_name + ".filelist.json")
     stats_output_file = os.path.join(output_dir, repo_name + ".stats.json")
     stats_error_file = os.path.join(output_dir, repo_name + ".stats.err")
 
     if not dry:
+        debugLog.log(msg=repo_name, tag="Analyzing repository with Modernmetric", display=True)
         with open(stats_input_file, 'w') as f:
             f.write(json.dumps(filelist, indent=4))
 
@@ -429,8 +446,8 @@ def scanRepos(config):
                 parseRepo(temp_dir, repo_name)
 
                 os.chdir(curr_dir)
-                if not dry:
-                    shutil.rmtree(temp_dir)
+                #if not dry:
+                    #shutil.rmtree(temp_dir)
         else:
              debugLog.log(msg='', tag="No remote repos", display=True)
     else:

--- a/verinfast/config.yaml
+++ b/verinfast/config.yaml
@@ -1,7 +1,7 @@
 # This is a sample config for test runs
 
 #baseurl: https://beta.startupos.dev/api/v2
-baseurl: http://localhost:5003
+baseurl: http://localhost:4000
 should_upload: true
 report:
   id: 541
@@ -10,16 +10,17 @@ modules:
     provider: corsis
     git:
       start: 2022-11-23
-    dry: false
+    dry: false # Flag to just reupload files
   cloud: 
-  - provider: azure
-    account: d6f7992c-2a21-4a9c-b46b-e70d2c90070d
-    start: "2023-05-01"
-    end: "2023-06-01"
-  - provider: aws
-    account: 436708548746
-    start: "2023-05-01"
-    end: "2023-06-01"
+  # - provider: azure
+  #   account: d6f7992c-2a21-4a9c-b46b-e70d2c90070d
+  #   start: "2023-05-01"
+  #   end: "2023-06-01"
+  # - provider: aws
+  #   account: 436708548746
+  #   start: "2023-05-01"
+  #   end: "2023-06-01"
 repos:
   - git@github.com:StartupOS/small-test-repo.git
+#  - git@github.com:rails/rails.git
 localrepos:


### PR DESCRIPTION
This is for ticket https://nichols.atlassian.net/browse/SOS-440

 I noticed our Rails demo was reporting 9K lines of code for a 300MB repo, which seemed way off.

I used CLOC to measure the lines of code and some git command line options (in the ticket) and the actual lines of code are closer to 380K.  I spent a good deal of time debugging Modernmetric and found how it was using Pygment to get lines of code. It uses Pygment tokens and may have worked with prior versions of Pygment, but it fails. Instead of reengineering it, I found a supported tool called Pygount that uses Pygment to get actual lines of code and comments. 

The agent is still backward compatible and getting LOC with the old file scan method can be turned off in the config. All new metrics are stored in new values in the db (so we can compare, QA etc). There's a companion PR for SOS that goes with this agent.