### PR TITLE
Fix bug preventing the targeting of git branches with a "/"

### DIFF
--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -422,8 +422,8 @@ class Agent:
             repos = self.config.config["repos"]
             if repos:
                 for repo_url in repos:
-                    match = re.search(".*\/(.*)", repo_url)
-                    repo_name = match.group(1)
+                    match = repo_url.partition("/")
+                    repo_name = match[2]
                     if "@" in repo_name:
                         repo_url = "@".join(repo_url.split("@")[0:2])
 
@@ -463,8 +463,8 @@ class Agent:
             if localrepos:
                 for repo_path in localrepos:
                     a = Path(repo_path).absolute()
-                    match = re.search(".*\/(.*)", str(a))
-                    repo_name = match.group(1)
+                    match = str(a).partition("/")
+                    repo_name = match[2]
                     self.parseRepo(repo_path, repo_name)
             else:
                 self.log(msg='', tag="No local repos", display=True)


### PR DESCRIPTION
When targeting a specific branch of a git repository the scan would fail to clone the git repo. e.g.`git@github.com:StartupOS/verinfast.git@slash-fix` would work but `git@github.com:StartupOS/verinfast.git@hotfix/slash-fix` would fail. This was caused because of the regex match pattern using the second `/` instead of the first. By using `partition` the string is instead split on the first `/` which lets the script properly clone the repo and checkout the appropriate branch.