### PR TITLE
adding check

### DIFF
--- a/src/verinfast/dependencies/walkers/gemwalker.py
+++ b/src/verinfast/dependencies/walkers/gemwalker.py
@@ -134,6 +134,8 @@ class GemWalker(Walker):
                 self.entries.append(e)
 
     def get_license(self, name: str) -> str:
+        if name not in self.real_dependencies:
+            return ""
         version = self.real_dependencies[name]
         license = ""
         try:


### PR DESCRIPTION
Fixes Mark's issue with gemspec not in real_dependencies. Without a version we can't get a license so it just returns the empty string.