### PR TITLE
Better error catching for Get Caller Identity

### DIFF
--- a/src/verinfast/cloud/aws/blocks.py
+++ b/src/verinfast/cloud/aws/blocks.py
@@ -4,6 +4,7 @@ import json
 import os
 
 import boto3
+import botocore
 
 import verinfast.cloud.aws.regions as r
 
@@ -13,11 +14,16 @@ regions = r.regions
 def getBlocks(sub_id: str, log, path_to_output: str = "./"):
     session = boto3.Session()
     profiles = session.available_profiles
+    import botocore.exceptions
+
     right_session = None
     for profile in profiles:
         s2 = boto3.Session(profile_name=profile)
         sts = s2.client('sts')
-        id = sts.get_caller_identity()
+        try:
+            id = sts.get_caller_identity()
+        except botocore.exceptions.ClientError:
+            continue
         if int(id['Account']) == int(sub_id):
             right_session = s2
             break

--- a/src/verinfast/cloud/aws/blocks.py
+++ b/src/verinfast/cloud/aws/blocks.py
@@ -4,7 +4,7 @@ import json
 import os
 
 import boto3
-import botocore
+import botocore.exceptions
 
 import verinfast.cloud.aws.regions as r
 
@@ -14,8 +14,6 @@ regions = r.regions
 def getBlocks(sub_id: str, log, path_to_output: str = "./"):
     session = boto3.Session()
     profiles = session.available_profiles
-    import botocore.exceptions
-
     right_session = None
     for profile in profiles:
         s2 = boto3.Session(profile_name=profile)

--- a/src/verinfast/cloud/aws/instances.py
+++ b/src/verinfast/cloud/aws/instances.py
@@ -152,7 +152,10 @@ def get_instances(sub_id: int, path_to_output: str = "./") -> str | None:
     for profile in profiles:
         s2 = boto3.Session(profile_name=profile)
         sts = s2.client('sts')
-        id = sts.get_caller_identity()
+        try:
+            id = sts.get_caller_identity()
+        except botocore.exceptions.ClientError:
+            continue
         if str(id['Account']) == str(sub_id):
             right_session = s2
             break


### PR DESCRIPTION
Get Caller Identity can fail with an error when trying on profiles that aren't the current profile. This catches that so it can proceed.