### PR TITLE
Aws instances field fix

### DIFF
--- a/src/verinfast/cloud/aws/instances.py
+++ b/src/verinfast/cloud/aws/instances.py
@@ -216,13 +216,14 @@ def get_instances(sub_id: int, path_to_output: str = "./") -> str | None:
                             result["publicIp"] = instance['PublicIpAddress']
                         else:
                             result["publicIp"] = 'n/a'
-                        ni = instance["NetworkInterfaces"]
-                        for interface in ni:
-                            if 'Association' in interface:
-                                association = interface['Association']
-                                if 'PublicIp' in association:
-                                    public_ip = association['PublicIp']
-                                    result["publicIp"] = public_ip
+                        if "NetworkInterfaces" in instance:
+                            ni = instance["NetworkInterfaces"]
+                            for interface in ni:
+                                if 'Association' in interface:
+                                    association = interface['Association']
+                                    if 'PublicIp' in association:
+                                        public_ip = association['PublicIp']
+                                        result["publicIp"] = public_ip
                         my_instances.append(result)
         except botocore.exceptions.ClientError:
             pass

--- a/src/verinfast/cloud/aws/instances.py
+++ b/src/verinfast/cloud/aws/instances.py
@@ -195,18 +195,24 @@ def get_instances(sub_id: int, path_to_output: str = "./") -> str | None:
                             if 'AvailabilityZone' in placement:
                                 zone = placement['AvailabilityZone']
                                 region = zone[0:-1]
-                        result = {
-                            "id": instance["InstanceId"],
-                            "name": name,
-                            "state": instance["State"]["Name"],
-                            "type": instance['InstanceType'],
-                            "zone": zone,
-                            "region": region,
-                            "subnet": subnet_id,
-                            "architecture": instance['Architecture'],
-                            "vpc": instance['VpcId'],
-                        }
-                        if "PublicIpAddress" in result:
+                        try:
+                            result = {
+                                "id": instance["InstanceId"],
+                                "name": name,
+                                "state": instance["State"]["Name"],
+                                "type": instance['InstanceType'],
+                                "zone": zone,
+                                "region": region,
+                                "subnet": subnet_id,
+                                "architecture": instance['Architecture']
+                            }
+                        except KeyError:
+                            continue
+                        if "VpcId" in instance:
+                            result["vpc"] = instance['VpcId']
+                        else:
+                            result["vpc"] = 'n/a'
+                        if "PublicIpAddress" in instance:
                             result["publicIp"] = instance['PublicIpAddress']
                         else:
                             result["publicIp"] = 'n/a'


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Someone running the scan had this error for AWS scanning:
`2024-01-12 16:16:12 Successfully uploaded /Users/aaronwhite/sunfire/projects/bpc-crosslake/results/aws-cost-161748159447.json for AWS to https://techlens-dev.corsis.com/api/v2/report/uuid/be9d9529-72a6-45b8-8d61-317ff3fee20e/costs.: 
2024-01-12 16:19:56 ERROR: Error processing provider
2024-01-12 16:19:56 ERROR PROVIDER: {
    "account": "161748159447",
    "end": "2024-01m-12d",
    "profile": null,
    "provider": "aws",
    "start": "2023-07m-12d"
}
2024-01-12 16:19:56 ERROR: 'VpcId'
2024-01-12 16:19:56 ERROR STACK: Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/verinfast/agent.py", line 595, in scanCloud
    aws_instance_file = get_aws_instances(
                        ^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/verinfast/cloud/aws/instances.py", line 204, in get_instances
    "vpc": instance['VpcId'],
           ~~~~~~~~^^^^^^^^^
KeyError: 'VpcId'`

## Related issue number

n/a

## Checks

I'm not sure how to add testing for this. AWS no longer allows creation of EC2 without VpC.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.