### PR TITLE
Fixes for Windows 11

### DIFF
--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -30,6 +30,8 @@ from verinfast.user import initial_prompt, save_path
 
 from verinfast.dependencies.walk import walk as dependency_walk
 
+import errno, stat
+
 # from verinfast.pygments_patch import patch_pygments
 # from modernmetric.fp import file_process
 # If we want to run modernmetric directly
@@ -214,6 +216,7 @@ class Agent:
             return False
 
     def formatGitHash(self, hash: str):
+        hash = hash.replace("'","")
         message = std_exec(["git", "log", "-n1", "--pretty=format:%B", hash])
         author = std_exec(["git", "log", "-n1", "--pretty=format:%aN <%aE>", hash])
         commit = std_exec(["git", "log", "-n1", "--pretty=format:%H", hash])
@@ -354,7 +357,7 @@ class Agent:
                 # print(subdirs)
                 for name in list:
                     fp = os.path.join(filepath, name)
-                    extRe = re.search("^[^\.]*\.(.*)", name)
+                    extRe = re.search(r"^[^\.]*\.(.*)", name)
                     ext = extRe.group(1) if extRe else ''
                     if self.allowfile(path=fp):
                         if self.config.shouldManualFileScan:
@@ -499,6 +502,11 @@ class Agent:
                 source=repo_name
             )
 
+    def handleRemoveReadonly(_agent, func, path, _exp):
+        print(path)
+        os.chmod(path, stat.S_IWRITE)
+        func(path)
+
     # ##### Scan Repos ######
     def scanRepos(self):
         # Loop over all remote repositories from config file
@@ -506,12 +514,12 @@ class Agent:
             repos = self.config.config["repos"]
             if repos:
                 for repo_url in [r for r in repos if len(r) > 0]:       # ignore blank lines from server
-                    match = re.search("([^/]*\.git.*)", repo_url)
+                    match = re.search(r"([^/]*\.git.*)", repo_url)
                     if match:
                         repo_name = match.group(1)
                     else:
                         repo_name = repo_url.rsplit('/', 1)[-1]
-                    if "@" in repo_name and re.search("^.*@.*\..*:", repo_url):
+                    if "@" in repo_name and re.search(r"^.*@.*\..*:", repo_url):
                         repo_url = "@".join(repo_url.split("@")[0:2])
                     elif "@" in repo_name:
                         repo_url = repo_url.split("@")[0]
@@ -539,7 +547,7 @@ class Agent:
 
                     os.chdir(curr_dir)
                     if not self.config.dry and self.config.delete_temp:
-                        shutil.rmtree(temp_dir)
+                        shutil.rmtree(temp_dir, onerror=self.handleRemoveReadonly)
             else:
                 self.log(msg='', tag="No remote repos", display=True)
 
@@ -552,7 +560,7 @@ class Agent:
             if localrepos:
                 for repo_path in localrepos:
                     a = Path(repo_path).absolute()
-                    match = re.search("([^/]*\.git.*)", str(a))
+                    match = re.search(r"([^/]*\.git.*)", str(a))
                     if match:
                         repo_name = match.group(1)
                     else:

--- a/src/verinfast/cloud/azure/costs.py
+++ b/src/verinfast/cloud/azure/costs.py
@@ -55,7 +55,7 @@ def runAzure(subscription_id, start, end, path_to_output):
         stdout=subprocess.PIPE
     )
 
-    bearer_token = "Bearer "+results.stdout.decode()[:-1]
+    bearer_token = "Bearer "+results.stdout.decode().rstrip()
     # print(bearer_token)
     print("Fetching data for subscription: " + subscription_id)
     conn.request(


### PR DESCRIPTION
## Environment

Python 3.12.1
pip 23.3.2
verinfast Latest
Git 2.43.0.windows.1
Windows 11 Latest
PowerShell & Latest

## Why are these changes needed?

Was unable to run on my Windows setup. I don't use Python very often, and when I do it's not on Windows. So, I still wouldn't be surprised if I was suffering from environmental factors. But Google was suggesting that some of this stuff is Windows related.

Usually I'd split into separate PRs, but here we go.

Extra quotes wrapping the hash. - [L219](https://github.com/StartupOS/verinfast/compare/StartupOS:988de7a...kim3er:46057c1#diff-7f62867738681f4dde174efaa81997dc94e37c7d30d67ba8ddc0b1db5dade0e2R219)

Folders created by the script were marked as Read Only, which the script was then unable to remove. - [L505-L508](https://github.com/StartupOS/verinfast/compare/StartupOS:988de7a...kim3er:46057c1#diff-7f62867738681f4dde174efaa81997dc94e37c7d30d67ba8ddc0b1db5dade0e2R505-R508) & [L550](https://github.com/StartupOS/verinfast/compare/StartupOS:988de7a...kim3er:46057c1#diff-7f62867738681f4dde174efaa81997dc94e37c7d30d67ba8ddc0b1db5dade0e2R550)

One line 58 of costs.py, it was only stripping a single character for new line. But on Windows you get new line and carriage return.

I was also getting line ending warnings on a few lines until I preceded the regexes with `r`.

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

I did not create a test environment for this PR. However, I did successfully upload data as a result of these changes.