### PR TITLE
Sos 651 ruby dependency walking returning object for source not string

### DIFF
--- a/src/verinfast/dependencies/walkers/gemwalker.py
+++ b/src/verinfast/dependencies/walkers/gemwalker.py
@@ -19,7 +19,7 @@ class GemWalker(Walker):
         command = f"gem install -r --explain --no-user-install --install-dir gems -g {file}"
         try:
             results = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            self.loggerFunc(msg=results.stderr.decode())
+            self.loggerFunc(msg=f'gem install results: {results.stderr.decode()}')
 
             log = results.stdout.decode()
             self.real_dependencies = {}
@@ -33,8 +33,8 @@ class GemWalker(Walker):
                     gem_version = line[split_position+1:]
                     self.real_dependencies[gem_name] = gem_version
         except:  # noqa:E722
+            self.loggerFunc(msg=f"Failed to parse Gemfile {file}", display=True)
             with open(file, "r") as manifest:
-                self.loggerFunc(msg="Failed to parse Gemfile")
                 self.loggerFunc(msg=file)
                 contents = manifest.read()
                 self.loggerFunc(msg=contents+"\n\n\n")

--- a/tests/gemfile
+++ b/tests/gemfile
@@ -16,7 +16,6 @@ gem 'rubocop-rspec', '~> 2.25.0'
 # https://github.com/codeclimate/test-reporter/issues/418
 gem 'simplecov', '~> 0.10', '< 0.18'
 gem 'stackprof', platform: :mri
-gem 'test-queue'
 gem 'yard', '~> 0.9'
 
 group :test do
@@ -34,3 +33,14 @@ gem 'rubocop-ast', path: local_ast if Dir.exist? local_ast
 
 local_gemfile = File.expand_path('Gemfile.local', __dir__)
 eval_gemfile local_gemfile if File.exist?(local_gemfile)
+
+# Import Gemfile_B
+eval_gemfile 'gemnest/Gemfile'
+
+# Use gems from a custom Git, private repository
+source 'https://github.com/example/gems.git' do
+    gem 'custom_gem', '1.0.0'
+  end
+
+# Another Gem after custom
+gem 'test-queue'

--- a/tests/gemnest/gemfile
+++ b/tests/gemnest/gemfile
@@ -1,0 +1,5 @@
+# Gemfile_B
+
+# Additional gems for Gemfile A
+gem 'devise', '4.8.1'
+gem 'carrierwave', '2.1.0'

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -77,6 +77,15 @@ def test_ruby():
                 found_azure_core = True
                 assert d["specifier"] == "*"
         assert found_azure_core
+        found_bad_source_type = False
+        found_source_single_quote = False
+        for d in output:
+            if type(d["source"]) is dict:
+                found_bad_source_type = True
+            elif d["source"].find("'") != -1:
+                found_source_single_quote = True
+        assert not found_bad_source_type
+        assert not found_source_single_quote
 
     return None
 

--- a/tests/test_dry.py
+++ b/tests/test_dry.py
@@ -30,7 +30,7 @@ def test_no_config(self):
     agent.config.shouldUpload = True
     agent.debug = DebugLog(path=agent.config.output_dir, debug=False)
     agent.log = agent.debug.log
-    print(agent.debug.logFile)
+    agent.uploader.config = config.upload_config
     agent.scan()
     assert Path(results_dir).exists()
     files = os.listdir(results_dir)

--- a/tests/test_dry.py
+++ b/tests/test_dry.py
@@ -30,7 +30,7 @@ def test_no_config(self):
     agent.config.shouldUpload = True
     agent.debug = DebugLog(path=agent.config.output_dir, debug=False)
     agent.log = agent.debug.log
-    agent.uploader.config = config.upload_config
+    agent.uploader.config = config.upload_conf
     agent.scan()
     assert Path(results_dir).exists()
     files = os.listdir(results_dir)


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This fixes two issues. First, in some cases, the "source" parameter for a gem dependency was being set as a source dictionary and not a string because of a missing "[]". Second, there are cases where a malformed gem file was causing a reference to List[-1] when the List was at length=0. I wrapped those in better error checking.

## Related issue number

SOS-651

## Checks

- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.

I modified the gemfile to reproduce both bad behaviour, verified it fails with main, passes with this PR.
- [x] I've made sure all auto checks have passed.