### PR TITLE
Fixed multi AWS cost issue

### DIFF
--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -672,33 +672,40 @@ class Agent:
                         path_to_output=self.config.output_dir,
                         dry=self.config.dry
                     )
-                    self.log(msg=aws_instance_file, tag="AWS Instances")
-                    self.upload(
-                        file=aws_instance_file,
-                        route="instances",
-                        source="AWS"
-                    )
+                    if aws_instance_file is None:
+                        self.log(msg="Error processing AWS instances", tag=account_id)
+                    else:
+                        self.log(msg=aws_instance_file, tag="AWS Instances")
+                        self.upload(
+                            file=aws_instance_file,
+                            route="instances",
+                            source="AWS"
+                        )
                     aws_utilization_file = os.path.join(
-                        path_to_output,
-                        f'aws-instances-{targeted_account}-utilization.json'
-    )
-                    self.upload(
-                        file=aws_utilization_file,
-                        route="utilization",
-                        source="AWS"
+                        self.config.output_dir,
+                        f'aws-instances-{account_id}-utilization.json'
                     )
+                    if Path(aws_utilization_file).is_file():
+                        self.upload(
+                            file=aws_utilization_file,
+                            route="utilization",
+                            source="AWS"
+                        )
                     aws_block_file = get_aws_blocks(
                         sub_id=account_id,
                         path_to_output=self.config.output_dir,
                         log=self.log,
                         dry=self.config.dry
                     )
-                    self.log(msg=aws_block_file, tag="AWS Storage")
-                    self.upload(
-                        file=aws_block_file,
-                        route="storage",
-                        source="AWS"
-                    )
+                    if aws_block_file is None:
+                        self.log(msg="Error processing AWS blocks", tag=account_id)
+                    else:
+                        self.log(msg=aws_block_file, tag="AWS Storage")
+                        self.upload(
+                            file=aws_block_file,
+                            route="storage",
+                            source="AWS"
+                        )
 
                 # Check if Azure CLI is installed
                 if provider.provider == "azure" and self.checkDependency("az", "Azure Command-line tool"):
@@ -709,40 +716,53 @@ class Agent:
                         path_to_output=self.config.output_dir,
                         dry=self.config.dry
                     )
-                    self.log(msg=azure_cost_file, tag="Azure Costs")
-                    self.upload(
-                        file=azure_cost_file,
-                        route="costs",
-                        source="Azure"
-                    )
+                    if azure_cost_file is None:
+                        self.log(msg="Error processing Azure costs", tag=provider.account)
+                    else:
+                        self.log(msg=azure_cost_file, tag="Azure Costs")
+                        self.upload(
+                            file=azure_cost_file,
+                            route="costs",
+                            source="Azure"
+                        )
                     azure_instance_file = get_az_instances(
                         sub_id=provider.account,
                         path_to_output=self.config.output_dir,
                         dry=self.config.dry
                     )
-                    self.log(msg=azure_instance_file, tag="Azure instances")
-                    self.upload(
-                        file=azure_instance_file,
-                        route="instances",
-                        source="Azure"
+                    if azure_instance_file is None:
+                        self.log(msg="Error processing Azure instances", tag=provider.account)
+                    else:
+                        self.log(msg=azure_instance_file, tag="Azure instances")
+                        self.upload(
+                            file=azure_instance_file,
+                            route="instances",
+                            source="Azure"
+                        )
+                    azure_utilization_file = os.path.join(
+                        self.config.output_dir,
+                        f'azure-instances-{account_id}-utilization.json'
                     )
-                    azure_utilization_file = azure_instance_file[:-5] + "-utilization.json"
-                    self.upload(
-                        file=azure_utilization_file,
-                        route="utilization",
-                        source="AWS"
-                    )
+                    if Path(azure_utilization_file).is_file():
+                        self.upload(
+                            file=azure_utilization_file,
+                            route="utilization",
+                            source="AWS"
+                        )
                     azure_block_file = get_az_blocks(
                         sub_id=provider.account,
                         path_to_output=self.config.output_dir,
                         dry=self.config.dry
                     )
-                    self.log(msg=azure_block_file, tag="Azure Storage")
-                    self.upload(
-                        file=azure_block_file,
-                        route="storage",
-                        source="Azure"
-                    )
+                    if azure_block_file is None:
+                        self.log(msg="Error processing Azure blocks", tag=provider.account)
+                    else:
+                        self.log(msg=azure_block_file, tag="Azure Storage")
+                        self.upload(
+                            file=azure_block_file,
+                            route="storage",
+                            source="Azure"
+                        )
 
                 if provider.provider == "gcp" and self.checkDependency("gcloud", "Google Command-line tool"):
                     gcp_instance_file = get_gcp_instances(
@@ -750,29 +770,39 @@ class Agent:
                         path_to_output=self.config.output_dir,
                         dry=self.config.dry
                     )
-                    self.log(msg=gcp_instance_file, tag="GCP instances")
-                    self.upload(
-                        file=gcp_instance_file,
-                        route="instances",
-                        source="GCP"
+                    if gcp_instance_file is None:
+                        self.log(msg="Error processing GCP instances", tag=provider.account)
+                    else:
+                        self.log(msg=gcp_instance_file, tag="GCP instances")
+                        self.upload(
+                            file=gcp_instance_file,
+                            route="instances",
+                            source="GCP"
+                        )
+                    gcp_utilization_file = os.path.join(
+                        self.config.output_dir,
+                        f'gcp-instances-{provider.account}-utilization.json'
                     )
-                    gcp_utilization_file = gcp_instance_file[:-5] + "-utilization.json"
-                    self.upload(
-                        file=gcp_utilization_file,
-                        route="utilization",
-                        source="AWS"
-                    )
+                    if Path(gcp_utilization_file).is_file():
+                        self.upload(
+                            file=gcp_utilization_file,
+                            route="utilization",
+                            source="AWS"
+                        )
                     gcp_block_file = get_gcp_blocks(
                         sub_id=provider.account,
                         path_to_output=self.config.output_dir,
                         dry=self.config.dry
                     )
-                    self.log(msg=gcp_block_file, tag="GCP Storage")
-                    self.upload(
-                        file=gcp_block_file,
-                        route="storage",
-                        source="GCP"
-                    )
+                    if gcp_block_file is None:
+                        self.log(msg="Error processing GCP blocks", tag=provider.account)
+                    else:
+                        self.log(msg=gcp_block_file, tag="GCP Storage")
+                        self.upload(
+                            file=gcp_block_file,
+                            route="storage",
+                            source="GCP"
+                        )
             except Exception as e:
                 self.log(tag="ERROR", msg="Error processing provider", display=True)
                 self.log(

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -623,7 +623,7 @@ class Agent:
             if localrepos:
                 for repo_path in localrepos:
                     a = Path(repo_path).absolute()
-                    match = re.search("([^/]*\.git.*)", str(a))
+                    match = re.search(r"([^/]*\.git.*)", str(a))
                     if match:
                         repo_name = match.group(1)
                     else:

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -218,6 +218,7 @@ class Agent:
             return False
 
     def formatGitHash(self, hash: str):
+        hash = hash.replace("'", "").replace('"', "")
         message = std_exec(["git", "log", "-n1", "--pretty=format:%B", hash])
         author = std_exec(["git", "log", "-n1", "--pretty=format:%aN <%aE>", hash])
         commit = std_exec(["git", "log", "-n1", "--pretty=format:%H", hash])

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -647,11 +647,15 @@ class Agent:
                 # Check if AWS-CLI is installed
                 if provider.provider == "aws" and self.checkDependency("aws", "AWS Command-line tool"):
                     account_id = str(provider.account).replace('-', '')
+                    if provider.profile is None:
+                        profile = find_profile(account_id, self.log)
+                    else:
+                        profile = provider.profile
                     aws_cost_file = runAws(
                         targeted_account=account_id,
                         start=provider.start,
                         end=provider.end,
-                        profile=provider.profile,
+                        profile=profile,
                         path_to_output=self.config.output_dir,
                         log=self.log,
                         dry=self.config.dry

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -363,7 +363,7 @@ class Agent:
             for filepath, subdirs, list in os.walk("."):
                 for name in list:
                     fp = os.path.join(filepath, name)
-                    extRe = re.search("^[^\.]*\.(.*)", name)
+                    extRe = re.search(r"^[^\.]*\.(.*)", name)
                     ext = extRe.group(1) if extRe else ''
                     if self.allowfile(path=fp):
                         if self.config.shouldManualFileScan:
@@ -510,12 +510,12 @@ class Agent:
             repos = self.config.config["repos"]
             if repos:
                 for repo_url in [r for r in repos if len(r) > 0]:       # ignore blank lines from server
-                    match = re.search("([^/]*\.git.*)", repo_url)
+                    match = re.search(r"([^/]*\.git.*)", repo_url)
                     if match:
                         repo_name = match.group(1)
                     else:
                         repo_name = repo_url.rsplit('/', 1)[-1]
-                    if "@" in repo_name and re.search("^.*@.*\..*:", repo_url):
+                    if "@" in repo_name and re.search(r"^.*@.*\..*:", repo_url):
                         repo_url = "@".join(repo_url.split("@")[0:2])
                     elif "@" in repo_name:
                         repo_url = repo_url.split("@")[0]
@@ -562,12 +562,12 @@ class Agent:
             repos = self.config.config["repos"]
             if repos:
                 for repo_url in [r for r in repos if len(r) > 0]:       # ignore blank lines from server
-                    match = re.search("([^/]*\.git.*)", repo_url)
+                    match = re.search(r"([^/]*\.git.*)", repo_url)
                     if match:
                         repo_name = match.group(1)
                     else:
                         repo_name = repo_url.rsplit('/', 1)[-1]
-                    if "@" in repo_name and re.search("^.*@.*\..*:", repo_url):
+                    if "@" in repo_name and re.search(r"^.*@.*\..*:", repo_url):
                         repo_url = "@".join(repo_url.split("@")[0:2])
                     elif "@" in repo_name:
                         repo_url = repo_url.split("@")[0]

--- a/src/verinfast/cloud/aws/costs.py
+++ b/src/verinfast/cloud/aws/costs.py
@@ -17,7 +17,7 @@ def runAws(targeted_account, start, end, path_to_output,
             --granularity=DAILY \
             --metrics "BlendedCost" \
             --group-by Type=DIMENSION,Key=SERVICE \
-            --profile={profile} \
+            --profile='{profile}' \
             --output=json | cat
         '''
 
@@ -70,7 +70,8 @@ def runAws(targeted_account, start, end, path_to_output,
 
     if profile is None:
         log(msg="No matching profiles found",
-            tag="AWS Available Accounts")
+            tag=targeted_account)
+        return None
 
     output_file = os.path.join(
         path_to_output,

--- a/src/verinfast/cloud/aws/costs.py
+++ b/src/verinfast/cloud/aws/costs.py
@@ -17,7 +17,7 @@ def runAws(targeted_account, start, end, path_to_output,
             --granularity=DAILY \
             --metrics "BlendedCost" \
             --group-by Type=DIMENSION,Key=SERVICE \
-            --profile='{profile}' \
+            --profile="{profile}" \
             --output=json | cat
         '''
 

--- a/src/verinfast/cloud/aws/get_profile.py
+++ b/src/verinfast/cloud/aws/get_profile.py
@@ -19,7 +19,7 @@ def find_profile(targeted_account: str, log=debugLog.log):
     text = results.stdout.decode()
     for line in text.splitlines():
         profiles.append(line)
-        cmd = f"aws sts get-caller-identity --profile='{line}' --output=json"
+        cmd = f'aws sts get-caller-identity --profile="{line}" --output=json'
         try:
             results = subprocess.run(
                 cmd,

--- a/src/verinfast/cloud/aws/get_profile.py
+++ b/src/verinfast/cloud/aws/get_profile.py
@@ -17,10 +17,9 @@ def find_profile(targeted_account: str, log=debugLog.log):
         stdout=subprocess.PIPE
     )
     text = results.stdout.decode()
-
     for line in text.splitlines():
         profiles.append(line)
-        cmd = f"aws sts get-caller-identity --profile={line} --output=json"
+        cmd = f"aws sts get-caller-identity --profile='{line}' --output=json"
         try:
             results = subprocess.run(
                 cmd,
@@ -35,9 +34,9 @@ def find_profile(targeted_account: str, log=debugLog.log):
         identity = json.loads(text)
         account = identity["Account"]
         available_accounts.append(account)
-
         if str(account) == str(targeted_account):
             return line
 
     debugLog.log(msg=profiles, tag="AWS Profiles")
     debugLog.log(msg=available_accounts, tag="AWS Available Accounts")
+    return None

--- a/tests/aws_conf.yaml
+++ b/tests/aws_conf.yaml
@@ -4,3 +4,7 @@ modules:
         account: 436708548746
         start: "2023-05-01"
         end: "2023-09-01"
+      - provider: aws
+        start: 2023-08-01
+        end: 2024-03-01
+        account: "foo" #Account with no profile

--- a/tests/aws_conf.yaml
+++ b/tests/aws_conf.yaml
@@ -5,6 +5,6 @@ modules:
         start: "2023-05-01"
         end: "2023-09-01"
       - provider: aws
-        start: 2023-08-01
-        end: 2024-03-01
+        start: "2023-08-01"
+        end: "2024-03-01"
         account: "foo" #Account with no profile

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -43,6 +43,9 @@ def test_aws_scan(self):
     with open(results_dir.joinpath(f"aws-cost-{sub_id}.json")) as f:
         costs = json.load(f)
         assert len(costs["data"]) >= 100
+    # Make sure "aws-cost-foo.json" doesn't exist
+    my_file = Path(results_dir.joinpath("aws-cost-foo.json"))
+    assert not my_file.is_file()
     with open(results_dir.joinpath(f"aws-instances-{sub_id}.json")) as f:
         instances = json.load(f)
         assert len(instances["data"]) >= 5

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -44,11 +44,14 @@ def test_aws_scan(self):
         costs = json.load(f)
         assert len(costs["data"]) >= 100
     # Make sure "aws-cost-foo.json" doesn't exist
-    my_file = Path(results_dir.joinpath("aws-cost-foo.json"))
-    assert not my_file.is_file()
+    bad_costs_file = Path(results_dir.joinpath("aws-cost-foo.json"))
+    assert not bad_costs_file.is_file()
     with open(results_dir.joinpath(f"aws-instances-{sub_id}.json")) as f:
         instances = json.load(f)
         assert len(instances["data"]) >= 5
+    # Make sure "aws-instances-foo.json" doesn't exist
+    bad_instances_file = Path(results_dir.joinpath("aws-instances-foo.json"))
+    assert not bad_instances_file.is_file()
     with open(
         results_dir.joinpath(f"aws-instances-{sub_id}-utilization.json")
     ) as f:
@@ -58,6 +61,11 @@ def test_aws_scan(self):
             if u["id"] == "i-0a3493d5abcdfba4b":
                 v = u["metrics"]
         assert len(v) >= 450
+    # Make sure "aws-instances-foo-utilization.json" doesn't exist
+    bad_utilization_file = Path(
+        results_dir.joinpath("aws-instances-foo-utilization.json")
+    )
+    assert not bad_utilization_file.is_file()
     with open(results_dir.joinpath(f"aws-storage-{sub_id}.json")) as f:
         storage = json.load(f)
         v = 0
@@ -65,6 +73,9 @@ def test_aws_scan(self):
             if u["name"] == "startupos-test-bucket":
                 v = u["size"]
         assert v >= 262183
+    # Make sure "aws-storage-foo.json" doesn't exist
+    bad_storage_file = Path(results_dir.joinpath("aws-storage-foo.json"))
+    assert not bad_storage_file.is_file()
 
 
 @patch('verinfast.user.__get_input__', return_value='y')


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If you put multiple AWS accounts in the config, currently, it will run costs on the current default AWS profile one time for each account, uploading a multiple of the identical real costs.

I added a lot more error checking in cloud in general. For example, if Instances failed, there was no name of the Instances file to modify to make the name of the Utilization file. And we would try to upload anything even if it failed.

Also, AWS profile names can have spaces, so they need to be wrapped in '' for command-line calls.

I also added lead "r" to our regular expressions to remove a deprecation warning.

Also added `hash = hash.replace("'", "").replace('"', '')` to better clean data.

## Related issue number

TEC-160

## Checks

- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. - Added a bad AWS account ID to the test conf ("foo").
- [x] I've made sure all auto checks have passed. 