### PR TITLE
Truncate findings

### DIFF
--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -446,7 +446,8 @@ class Agent:
                     with open(findings_output_file) as f:
                         original_findings = json.load(f)
 
-                    if self.config.truncate_findings:
+                    print('self.config.truncate_findings', self.config.truncate_findings)
+                    if self.config.truncate_findings >= 0:
                         truncation_exclusion = ["cwe", "path", "check_id", "license"]
                         self.log(
                             tag="TRUNCATING",
@@ -457,7 +458,7 @@ class Agent:
                                 findings,
                                 self.log,
                                 excludes=truncation_exclusion,
-                                max_length=self.config.truncate_findings_length
+                                max_length=self.config.truncate_findings
                             )
                         except Exception as e:
                             self.log(tag="ERROR", msg="Error in Truncation")

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -446,9 +446,8 @@ class Agent:
                     with open(findings_output_file) as f:
                         original_findings = json.load(f)
 
-                    print('self.config.truncate_findings', self.config.truncate_findings)
                     if self.config.truncate_findings >= 0:
-                        truncation_exclusion = ["cwe", "path", "check_id", "license"]
+                        truncation_exclusion = ["cwe", "owasp", "path", "check_id", "license"]
                         self.log(
                             tag="TRUNCATING",
                             msg=f"excluding: {truncation_exclusion}"
@@ -458,7 +457,8 @@ class Agent:
                                 findings,
                                 self.log,
                                 excludes=truncation_exclusion,
-                                max_length=self.config.truncate_findings
+                                max_length=self.config.truncate_findings,
+                                key_name='lines'
                             )
                         except Exception as e:
                             self.log(tag="ERROR", msg="Error in Truncation")

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -446,7 +446,7 @@ class Agent:
                     with open(findings_output_file) as f:
                         original_findings = json.load(f)
 
-                    if self.config.truncate_findings >= 0:
+                    if self.config.truncate_findings:
                         # Exclusions are set to exclude fields that are not code
                         truncation_exclusion = [
                             "cwe",
@@ -470,7 +470,7 @@ class Agent:
                                 findings,
                                 self.log,
                                 excludes=truncation_exclusion,
-                                max_length=self.config.truncate_findings
+                                max_length=self.config.truncate_findings_length
                             )
                         except Exception as e:
                             self.log(tag="ERROR", msg="Error in Truncation")

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -447,7 +447,20 @@ class Agent:
                         original_findings = json.load(f)
 
                     if self.config.truncate_findings >= 0:
-                        truncation_exclusion = ["cwe", "owasp", "path", "check_id", "license"]
+                        # Exclusions are set to exclude fields that are not code
+                        truncation_exclusion = [
+                            "cwe",
+                            "owasp",
+                            "path",
+                            "check_id",
+                            "license",
+                            "fingerprint",
+                            "message",
+                            "references",
+                            "url",
+                            "source",
+                            "severity"
+                        ]
                         self.log(
                             tag="TRUNCATING",
                             msg=f"excluding: {truncation_exclusion}"
@@ -457,8 +470,7 @@ class Agent:
                                 findings,
                                 self.log,
                                 excludes=truncation_exclusion,
-                                max_length=self.config.truncate_findings,
-                                key_name=['lines', 'taint_source']
+                                max_length=self.config.truncate_findings
                             )
                         except Exception as e:
                             self.log(tag="ERROR", msg="Error in Truncation")

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -458,7 +458,7 @@ class Agent:
                                 self.log,
                                 excludes=truncation_exclusion,
                                 max_length=self.config.truncate_findings,
-                                key_name='lines'
+                                key_name=['lines', 'taint_source']
                             )
                         except Exception as e:
                             self.log(tag="ERROR", msg="Error in Truncation")

--- a/src/verinfast/config.py
+++ b/src/verinfast/config.py
@@ -387,7 +387,6 @@ class Config(printable):
             self.runGit = args.should_git
 
         if "truncate_findings" in args and args.truncate_findings is not None:
-            print('args.truncate_findings', args.truncate_findings)
             if args.truncate_findings >= 0:
                 self.truncate_findings = args.truncate_findings
             else:
@@ -426,10 +425,7 @@ class Config(printable):
             if "delete_temp" in self.config:
                 self.delete_temp = self.config["delete_temp"]
             if "truncate_findings" in self.config:
-                print('self.config["truncate_findings"]', 
-                      self.config["truncate_findings"])
                 self.truncate_findings = self.config["truncate_findings"]
-                print('self.truncate_findings', self.truncate_findings)
 
             if "server" in self.config:
                 s = self.config["server"]

--- a/src/verinfast/config.py
+++ b/src/verinfast/config.py
@@ -174,8 +174,7 @@ class Config(printable):
     server_cost_separator: str | None = None
     shouldUpload: bool = False
     shouldManualFileScan: bool = True
-    truncate_findings = False
-    truncate_findings_length = 30
+    truncate_findings = -1
     upload_logs = False
     use_uuid = False
 
@@ -289,10 +288,9 @@ class Config(printable):
             "-t", "--truncate", "--truncate_findings",
             dest="truncate_findings",
             type=int,
-            default=-1,
             help="""This flag will further enhance privacy by capping
-            The length of security warnings. It defaults to unlimited,
-            but can be set to any level you feel comfortable with.
+            The length of security warning code snippets. It defaults to
+            unlimited, but can be set to any level you feel comfortable with.
 
             <0 = unlimited
             We recommend 30 as good balance between privacy and utility
@@ -389,11 +387,11 @@ class Config(printable):
             self.runGit = args.should_git
 
         if "truncate_findings" in args and args.truncate_findings is not None:
-            if args.truncate_findings > 0:
-                self.truncate_findings = True
-                self.truncate_findings_length = args.truncate_findings
+            print('args.truncate_findings', args.truncate_findings)
+            if args.truncate_findings >= 0:
+                self.truncate_findings = args.truncate_findings
             else:
-                self.truncate_findings = False
+                self.truncate_findings = -1
 
     def is_path_remote(self) -> bool:
         s = self.cfg_path
@@ -427,6 +425,11 @@ class Config(printable):
                 self.dry = self.config["dry"]
             if "delete_temp" in self.config:
                 self.delete_temp = self.config["delete_temp"]
+            if "truncate_findings" in self.config:
+                print('self.config["truncate_findings"]', 
+                      self.config["truncate_findings"])
+                self.truncate_findings = self.config["truncate_findings"]
+                print('self.truncate_findings', self.truncate_findings)
 
             if "server" in self.config:
                 s = self.config["server"]

--- a/src/verinfast/config.py
+++ b/src/verinfast/config.py
@@ -174,7 +174,8 @@ class Config(printable):
     server_cost_separator: str | None = None
     shouldUpload: bool = False
     shouldManualFileScan: bool = True
-    truncate_findings = -1
+    truncate_findings = False
+    truncate_findings_length = 30
     upload_logs = False
     use_uuid = False
 
@@ -288,9 +289,10 @@ class Config(printable):
             "-t", "--truncate", "--truncate_findings",
             dest="truncate_findings",
             type=int,
+            default=-1,
             help="""This flag will further enhance privacy by capping
-            The length of security warning code snippets. It defaults to
-            unlimited, but can be set to any level you feel comfortable with.
+            The length of security warnings. It defaults to unlimited,
+            but can be set to any level you feel comfortable with.
 
             <0 = unlimited
             We recommend 30 as good balance between privacy and utility
@@ -388,9 +390,10 @@ class Config(printable):
 
         if "truncate_findings" in args and args.truncate_findings is not None:
             if args.truncate_findings >= 0:
-                self.truncate_findings = args.truncate_findings
+                self.truncate_findings = True
+                self.truncate_findings_length = args.truncate_findings
             else:
-                self.truncate_findings = -1
+                self.truncate_findings = False
 
     def is_path_remote(self) -> bool:
         s = self.cfg_path
@@ -426,6 +429,11 @@ class Config(printable):
                 self.delete_temp = self.config["delete_temp"]
             if "truncate_findings" in self.config:
                 self.truncate_findings = self.config["truncate_findings"]
+                if "truncate_findings_length" in self.config:
+                    self.truncate_findings_length = \
+                        self.config["truncate_findings_length"]
+                else:
+                    self.truncate_findings_length = 30
 
             if "server" in self.config:
                 s = self.config["server"]

--- a/src/verinfast/config.py
+++ b/src/verinfast/config.py
@@ -289,7 +289,6 @@ class Config(printable):
             "-t", "--truncate", "--truncate_findings",
             dest="truncate_findings",
             type=int,
-            default=-1,
             help="""This flag will further enhance privacy by capping
             The length of security warnings. It defaults to unlimited,
             but can be set to any level you feel comfortable with.

--- a/src/verinfast/utils/utils.py
+++ b/src/verinfast/utils/utils.py
@@ -72,7 +72,8 @@ def truncate_children(
             log,
             excludes=[],
             max_length=30,
-            recursion_depth=0
+            recursion_depth=0,
+            key_name=None
         ):
     if isinstance(obj, dict):
         for k in obj:
@@ -80,7 +81,11 @@ def truncate_children(
             if k in excludes:
                 pass
             elif isinstance(v, str):
-                obj[k] = v[0:max_length]
+                if key_name:
+                    if k == key_name:
+                        obj[k] = v[0:max_length]
+                else:
+                    obj[k] = v[0:max_length]
             elif (
                 isinstance(v, int) or
                 isinstance(v, float) or
@@ -93,11 +98,12 @@ def truncate_children(
                     log,
                     excludes=excludes,
                     max_length=max_length,
-                    recursion_depth=recursion_depth + 1
+                    recursion_depth=recursion_depth + 1,
+                    key_name=key_name
                 )
     elif isinstance(obj, list):
         for i, v in enumerate(obj):
-            if isinstance(v, str):
+            if isinstance(v, str) and key_name is None:
                 obj[i] = v[0:max_length]
             elif (
                 isinstance(v, int) or
@@ -111,7 +117,8 @@ def truncate_children(
                     log,
                     excludes=excludes,
                     max_length=max_length,
-                    recursion_depth=recursion_depth + 1
+                    recursion_depth=recursion_depth + 1,
+                    key_name=key_name
                 )
 
     return obj

--- a/src/verinfast/utils/utils.py
+++ b/src/verinfast/utils/utils.py
@@ -73,7 +73,8 @@ def truncate_children(
             excludes=[],
             max_length=30,
             recursion_depth=0,
-            key_name=None
+            key_name=None,
+            parent_key=None
         ):
     if isinstance(obj, dict):
         for k in obj:
@@ -82,7 +83,7 @@ def truncate_children(
                 pass
             elif isinstance(v, str):
                 if key_name:
-                    if k == key_name:
+                    if k in key_name:
                         obj[k] = v[0:max_length]
                 else:
                     obj[k] = v[0:max_length]
@@ -99,11 +100,14 @@ def truncate_children(
                     excludes=excludes,
                     max_length=max_length,
                     recursion_depth=recursion_depth + 1,
-                    key_name=key_name
+                    key_name=key_name,
+                    parent_key=k
                 )
     elif isinstance(obj, list):
         for i, v in enumerate(obj):
             if isinstance(v, str) and key_name is None:
+                obj[i] = v[0:max_length]
+            elif isinstance(v, str) and parent_key in key_name:
                 obj[i] = v[0:max_length]
             elif (
                 isinstance(v, int) or
@@ -118,7 +122,8 @@ def truncate_children(
                     excludes=excludes,
                     max_length=max_length,
                     recursion_depth=recursion_depth + 1,
-                    key_name=key_name
+                    key_name=key_name,
+                    parent_key=parent_key
                 )
 
     return obj

--- a/src/verinfast/utils/utils.py
+++ b/src/verinfast/utils/utils.py
@@ -72,9 +72,7 @@ def truncate_children(
             log,
             excludes=[],
             max_length=30,
-            recursion_depth=0,
-            key_name=None,
-            parent_key=None
+            recursion_depth=0
         ):
     if isinstance(obj, dict):
         for k in obj:
@@ -82,11 +80,7 @@ def truncate_children(
             if k in excludes:
                 pass
             elif isinstance(v, str):
-                if key_name:
-                    if k in key_name:
-                        obj[k] = v[0:max_length]
-                else:
-                    obj[k] = v[0:max_length]
+                obj[k] = v[0:max_length]
             elif (
                 isinstance(v, int) or
                 isinstance(v, float) or
@@ -99,15 +93,11 @@ def truncate_children(
                     log,
                     excludes=excludes,
                     max_length=max_length,
-                    recursion_depth=recursion_depth + 1,
-                    key_name=key_name,
-                    parent_key=k
+                    recursion_depth=recursion_depth + 1
                 )
     elif isinstance(obj, list):
         for i, v in enumerate(obj):
-            if isinstance(v, str) and key_name is None:
-                obj[i] = v[0:max_length]
-            elif isinstance(v, str) and parent_key in key_name:
+            if isinstance(v, str):
                 obj[i] = v[0:max_length]
             elif (
                 isinstance(v, int) or
@@ -121,9 +111,7 @@ def truncate_children(
                     log,
                     excludes=excludes,
                     max_length=max_length,
-                    recursion_depth=recursion_depth + 1,
-                    key_name=key_name,
-                    parent_key=parent_key
+                    recursion_depth=recursion_depth + 1
                 )
 
     return obj

--- a/tests/test_truncate.py
+++ b/tests/test_truncate.py
@@ -145,7 +145,8 @@ def test_truncate(self):
     agent.config = config
     agent.config.dry = False
     agent.config.shouldUpload = False
-    agent.config.truncate_findings = 0
+    agent.config.truncate_findings = True
+    agent.config.truncate_findings_length = 0
     assert agent.config.runGit is True
     assert agent.config.runScan is True
     agent.debug = DebugLog(path=agent.config.output_dir, debug=False)

--- a/tests/test_truncate.py
+++ b/tests/test_truncate.py
@@ -182,10 +182,12 @@ def test_truncate_from_args(self):
     config.handle_args(args)
     assert config.runGit is True
     assert config.runScan is True
-    assert config.truncate_findings == 30
+    assert config.truncate_findings is True
+    assert config.truncate_findings_length == 30
     config.output_dir = results_dir
     agent.config = config
-    assert agent.config.truncate_findings == 30
+    assert agent.config.truncate_findings is True
+    assert agent.config.truncate_findings_length == 30
     agent.config.dry = False
     agent.config.shouldUpload = False
     agent.debug = DebugLog(path=agent.config.output_dir, debug=False)

--- a/tests/test_truncate.py
+++ b/tests/test_truncate.py
@@ -22,12 +22,20 @@ def check_children(
             i: str | dict | list,
             max_length=30,
             recursion_depth=0,
+            # This list must match agent.py
             excludes=[
                 "cwe",
+                "owasp",
                 "path",
                 "check_id",
-                "license"
-            ],
+                "license",
+                "fingerprint",
+                "message",
+                "references",
+                "url",
+                "source",
+                "severity"
+            ]
         ):
     if recursion_depth > MAX_RECURSION_DEPTH:
         raise Exception("In TOO DEEP!")
@@ -108,14 +116,12 @@ def test_no_truncate(self):
                     k,
                     excludes=[
                         "cwe",
-                        "owasp",
                         "path",
                         "check_id",
                         "license",
                         "taint_sink",
                         "taint_source",
-                        "fingerprint",
-                        "lines"
+                        "fingerprint"
                     ]
                 )
     assert saw_message is True
@@ -153,22 +159,7 @@ def test_truncate(self):
         assert r[0]["check_id"] == "bash.curl.security.curl-eval.curl-eval"
         assert r[0]["extra"]["lines"] == ""
         for k in r:
-            check_children(
-                    k,
-                    excludes=[
-                        "cwe",
-                        "owasp",
-                        "path",
-                        "check_id",
-                        "license",
-                        "taint_sink",
-                        "fingerprint",
-                        "message",
-                        "references",
-                        "url",
-                        "source"
-                    ]
-                )
+            check_children(k)
     assert saw_message is True
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As it was, the agent only honored "truncate_findings" from the command line args and not the config.
It wouldn't work setting to truncate to zero
And it was truncating things like OWASP and Severity which broke the front end
test_truncate.py tests the changes

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ x ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ x ] I've made sure all auto checks have passed.