### PR TITLE
No preflight confirm if just cloud

### DIFF
--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -541,34 +541,34 @@ class Agent:
                         self.log(msg=repo_url, tag="Unable to access", display=True, timestamp=False)
                         self.log(msg=repo_url, tag="Repository will not be scanned", display=True, timestamp=False)
 
-            cloud_config = self.config.modules.cloud
-            if cloud_config is not None:
-                for provider in cloud_config:
-                    try:
-                        if provider.provider == "aws" and self.checkDependency("aws", "AWS Command-line tool"):
-                            account_id = str(provider.account).replace('-', '')
-                            if find_profile(account_id, self.log) is None:
-                                self.log(tag=f"No matching AWS CLI profiles found for {provider.account}", msg="Account can't be scanned.", display=True, timestamp=False)
-                            else:
-                                self.log(tag="AWS account access confirmed", msg=account_id, display=True, timestamp=False)
-                        if provider.provider == "azure" and self.checkDependency("az", "Azure Command-line tool"):
-                            pass
-                        if provider.provider == "gcp" and self.checkDependency("gcloud", "Google Command-line tool"):
-                            pass
-                    except:
-                        self.log(msg=f"Unable to access {provider.provider} {provider.account}", tag="Unable to access", display=True, timestamp=False)
+        cloud_config = self.config.modules.cloud
+        if cloud_config is not None:
+            for provider in cloud_config:
+                try:
+                    if provider.provider == "aws" and self.checkDependency("aws", "AWS Command-line tool"):
+                        account_id = str(provider.account).replace('-', '')
+                        if find_profile(account_id, self.log) is None:
+                            self.log(tag=f"No matching AWS CLI profiles found for {provider.account}", msg="Account can't be scanned.", display=True, timestamp=False)
+                        else:
+                            self.log(tag="AWS account access confirmed", msg=account_id, display=True, timestamp=False)
+                    if provider.provider == "azure" and self.checkDependency("az", "Azure Command-line tool"):
+                        pass
+                    if provider.provider == "gcp" and self.checkDependency("gcloud", "Google Command-line tool"):
+                        pass
+                except:
+                    self.log(msg=f"Unable to access {provider.provider} {provider.account}", tag="Unable to access", display=True, timestamp=False)
 
-                resp = repeat_boolean_prompt(
-                    "\nWould you like to proceed with the scan?",
-                    logger=print,
-                    default_val=True
-                )
+        resp = repeat_boolean_prompt(
+            "\nWould you like to proceed with the scan?",
+            logger=print,
+            default_val=True
+        )
 
-                if resp:
-                    self.log(msg="Proceeding")
-                else:
-                    self.log(tag="Exiting now", msg="", display=True)
-                    exit(0)
+        if resp:
+            self.log(msg="Proceeding")
+        else:
+            self.log(tag="Exiting now", msg="", display=True)
+            exit(0)
 
     # ##### Scan Repos ######
     def scanRepos(self):

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -46,7 +46,9 @@ def test_aws_scan(self):
     # Make sure "aws-cost-foo.json" doesn't exist
     bad_costs_file = Path(results_dir.joinpath("aws-cost-foo.json"))
     assert not bad_costs_file.is_file()
-    with open(results_dir.joinpath(f"aws-instances-{sub_id}.json")) as f:
+    instancesFile = results_dir.joinpath(f"aws-instances-{sub_id}.json")
+    print("instancesFile", instancesFile)
+    with open(instancesFile) as f:
         instances = json.load(f)
         assert len(instances["data"]) >= 5
     # Make sure "aws-instances-foo.json" doesn't exist
@@ -66,7 +68,9 @@ def test_aws_scan(self):
         results_dir.joinpath("aws-instances-foo-utilization.json")
     )
     assert not bad_utilization_file.is_file()
-    with open(results_dir.joinpath(f"aws-storage-{sub_id}.json")) as f:
+    storageFile = results_dir.joinpath(f"aws-storage-{sub_id}.json")
+    print("storageFile", storageFile)
+    with open(storageFile) as f:
         storage = json.load(f)
         v = 0
         for u in storage["data"]:


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
If the scan only included Cloud, the preflight messaging didn't show. It was just indents.

I didn't create a unit test, but I did QA. You can see the config and results in this screenshot:
![image](https://github.com/StartupOS/verinfast/assets/78375852/39b51d3d-2162-42b1-9877-db276a0ad591)


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.