### PR TITLE
Overwrite temp_repo message

### DIFF
--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -16,7 +16,7 @@ import httpx
 from jinja2 import Environment, FileSystemLoader
 from pygments_tsx.tsx import patch_pygments
 
-from verinfast.utils.utils import DebugLog, std_exec, trimLineBreaks, escapeChars, truncate, truncate_children
+from verinfast.utils.utils import DebugLog, std_exec, trimLineBreaks, escapeChars, truncate, truncate_children, delete_directory_with_chmod
 from verinfast.upload import Uploader
 
 from verinfast.cloud.aws.costs import runAws
@@ -598,10 +598,12 @@ class Agent:
                             default_val=False
                         )
                         if resp:
-                            os.chmod(temp_dir, 0o666)
-                            shutil.rmtree(temp_dir)
-                            os.makedirs(temp_dir)
-                            os.chmod(temp_dir, 0o666)
+                            try:
+                                delete_directory_with_chmod(temp_dir)
+                                os.makedirs(temp_dir)
+                            except Exception as e:
+                                self.log(tag=f"Failed to delete {temp_dir}", msg=e, display=True)
+                                continue
                         else:
                             self.log(f"Skipping {repo_url} due to existing temp_dir")
                             continue

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -594,7 +594,7 @@ class Agent:
                         self.log(tag="Directory exists:", msg=temp_dir, display=True)
                         resp = repeat_boolean_prompt(
                             "Should we overwrite?",
-                            self.log,
+                            logger=print,
                             default_val=False
                         )
                         if resp:

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -16,7 +16,7 @@ import httpx
 from jinja2 import Environment, FileSystemLoader
 from pygments_tsx.tsx import patch_pygments
 
-from verinfast.utils.utils import DebugLog, std_exec, trimLineBreaks, escapeChars, truncate, truncate_children, delete_directory_with_chmod
+from verinfast.utils.utils import DebugLog, std_exec, trimLineBreaks, escapeChars, truncate, truncate_children
 from verinfast.upload import Uploader
 
 from verinfast.cloud.aws.costs import runAws
@@ -599,7 +599,7 @@ class Agent:
                         )
                         if resp:
                             try:
-                                delete_directory_with_chmod(temp_dir)
+                                shutil.rmtree(temp_dir)
                                 os.makedirs(temp_dir)
                             except Exception as e:
                                 self.log(tag=f"Failed to delete {temp_dir}", msg=e, display=True)

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -55,7 +55,7 @@ templates_folder = str(parent_folder.joinpath("templates"))
 # str_path = str(parent_folder.joinpath('str_conf.yaml').absolute())
 
 curr_dir = os.getcwd()
-temp_dir = os.path.join(curr_dir, "temp_repo")
+temp_dir = os.path.join(curr_dir, "verinfast_repo")
 
 
 class Agent:
@@ -592,20 +592,11 @@ class Agent:
                             os.makedirs(temp_dir)
                     except:
                         self.log(tag="Directory exists:", msg=temp_dir, display=True)
-                        resp = repeat_boolean_prompt(
-                            "Should we overwrite?",
-                            logger=print,
-                            default_val=False
-                        )
-                        if resp:
-                            try:
-                                shutil.rmtree(temp_dir)
-                                os.makedirs(temp_dir)
-                            except Exception as e:
-                                self.log(tag=f"Failed to delete {temp_dir}", msg=e, display=True)
-                                continue
-                        else:
-                            self.log(f"Skipping {repo_url} due to existing temp_dir")
+                        try:
+                            shutil.rmtree(temp_dir)
+                            os.makedirs(temp_dir)
+                        except Exception as e:
+                            self.log(tag=f"Failed to delete {temp_dir}", msg=e, display=True)
                             continue
 
                     self.log(msg=repo_url, tag="Repo URL")

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -55,7 +55,7 @@ templates_folder = str(parent_folder.joinpath("templates"))
 # str_path = str(parent_folder.joinpath('str_conf.yaml').absolute())
 
 curr_dir = os.getcwd()
-temp_dir = os.path.join(curr_dir, "verinfast_repo")
+temp_dir = os.path.abspath(os.path.join('~/.verinfast/', "temp_repo"))
 
 
 class Agent:

--- a/src/verinfast/utils/utils.py
+++ b/src/verinfast/utils/utils.py
@@ -5,6 +5,7 @@ import re
 from glob import glob
 import subprocess
 import time
+import stat
 
 from typing import List
 
@@ -147,3 +148,17 @@ class DebugLog:
             f.write(output+"\n")
         if display or self.debug:
             print(output)
+
+
+# Delete a directory and all its contents, despite permissions
+def delete_directory_with_chmod(directory_path):
+    for root, dirs, files in os.walk(directory_path, topdown=False):
+        for file in files:
+            file_path = os.path.join(root, file)
+            os.chmod(file_path, stat.S_IWUSR)
+            os.remove(file_path)
+        for dir in dirs:
+
+            dir_path = os.path.join(root, dir)
+            os.rmdir(dir_path)
+    os.rmdir(directory_path)

--- a/src/verinfast/utils/utils.py
+++ b/src/verinfast/utils/utils.py
@@ -5,7 +5,6 @@ import re
 from glob import glob
 import subprocess
 import time
-import stat
 
 from typing import List
 
@@ -148,17 +147,3 @@ class DebugLog:
             f.write(output+"\n")
         if display or self.debug:
             print(output)
-
-
-# Delete a directory and all its contents, despite permissions
-def delete_directory_with_chmod(directory_path):
-    for root, dirs, files in os.walk(directory_path, topdown=False):
-        for file in files:
-            file_path = os.path.join(root, file)
-            os.chmod(file_path, stat.S_IWUSR)
-            os.remove(file_path)
-        for dir in dirs:
-
-            dir_path = os.path.join(root, dir)
-            os.rmdir(dir_path)
-    os.rmdir(directory_path)


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If temp repo is present, agent asks to confirm deletion. The message didn't show, though, just a "(y/N)"

Now it does.

I tested it and it failed to delete temp_repo on Ubuntu. So I updated the deletion code based on:
https://www.tutorialspoint.com/How-to-delete-a-Python-directory-effectively

I can't test on Mac.

I also think we should make the default option for the delete question to be Y. Users will arrive here after a scan failure and we want to delete.
```
2024-05-16 11:10:08 Processing: small-test-repo.git
2024-05-16 11:10:08 Directory exists:: /home/stconrad/quick_test/temp_repo
Should we overwrite?
(y/N)
```


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.