### PR TITLE
Azure variable referenced before assignment

### DIFF
--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -756,7 +756,7 @@ class Agent:
                         )
                     azure_utilization_file = os.path.join(
                         self.config.output_dir,
-                        f'azure-instances-{account_id}-utilization.json'
+                        f'azure-instances-{provider.account}-utilization.json'
                     )
                     if Path(azure_utilization_file).is_file():
                         self.upload(


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I was on a call with a target when they got an error scanning Azure: 'account_id' referenced before assignment. 

Account_id was added to remove '-' for AWS. I think this is a legacy CnP error. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.